### PR TITLE
Add uvicorn server with /mcp route

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,22 +40,32 @@ GRAFANA_API_TOKEN=your-api-token-here
 
 You can generate an API token in Grafana by navigating to: Configuration → API Keys → New API key.
 
-4. After installation, the MCP server can be run as:
+4. After installation, start the HTTP server:
 
 ```bash
 python -m grafana_mcp
 ```
 
-5. Add this MCP server to Claude Code:
+This runs a small `uvicorn` server that exposes the MCP API at `http://localhost:8000/mcp`.
+
+5. Add this MCP server to Claude Code. You can either use the convenient
+   `add` command or the lower-level JSON configuration:
 
 ```bash
-claude mcp add-json grafana '{ "type": "stdio", "command": "python", "args": [ "-m", "grafana_mcp" ], "env": {} }'
+# Simple syntax
+claude mcp add grafana http://localhost:8000/mcp
+
+# Equivalent JSON configuration
+claude mcp add-json grafana '{"type": "streamable_http", "url": "http://localhost:8000/mcp"}'
 ```
 
 Note: By default, MCP config applies only to the current directory. If you want to use it globally, add `--scope user` to the command above:
 
 ```bash
-claude mcp add-json --scope user grafana '{ "type": "stdio", "command": "python", "args": [ "-m", "grafana_mcp" ], "env": {} }'
+claude mcp add --scope user grafana http://localhost:8000/mcp
+
+# Or with JSON
+claude mcp add-json --scope user grafana '{"type": "streamable_http", "url": "http://localhost:8000/mcp"}'
 ```
 
 6. Run Claude Code as usual:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mcp>=1.3.0
 grafana-client>=4.3.2
 python-dotenv>=1.1.0
+requests>=2.31

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "mcp>=1.3.0",
         "grafana-client>=4.3.2",
         "python-dotenv>=1.1.0",
+        "requests>=2.31",
     ],
     python_requires=">=3.7",
 )

--- a/src/grafana_mcp/__main__.py
+++ b/src/grafana_mcp/__main__.py
@@ -1,14 +1,27 @@
 #!/usr/bin/env python3
+"""Grafana MCP server entry point.
+
+This module exposes a Starlette ``app`` that mounts the MCP server at the
+``/mcp`` route. Executing ``python -m grafana_mcp`` runs the app using
+``uvicorn``.
 """
-Grafana MCP server entry point
-"""
+
+from starlette.applications import Starlette
+import uvicorn
+import os
 
 from grafana_mcp.mcp_server import mcp
 
-def main():
-    """Main entry point for the application"""
-    print("Starting Grafana MCP server...")
-    mcp.run()
+# Starlette application with the MCP server mounted at /mcp
+app = Starlette()
+app.mount("/mcp", mcp.streamable_http_app())
+
+
+def main() -> None:
+    """Run the Starlette application using ``uvicorn``."""
+    print("Starting Grafana MCP server on http://0.0.0.0:8000/mcp ...")
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")))
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,6 +17,12 @@ class TestMCPServer(unittest.TestCase):
         """Test that the mcp instance is defined."""
         from grafana_mcp.mcp_server import mcp
         self.assertIsNotNone(mcp)
+
+    def test_app_mount(self):
+        """Ensure the Starlette app mounts the MCP server at /mcp."""
+        from grafana_mcp.__main__ import app
+        paths = [getattr(r, "path", None) for r in app.routes]
+        self.assertIn("/mcp", paths)
             
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expose Starlette app that serves MCP under `/mcp`
- run server with uvicorn when running `python -m grafana_mcp`
- document the HTTP server usage and Claude config
- show equivalent `claude mcp add-json` syntax
- add simple test verifying the Starlette mount
- install requests dependency
- clarify that the protocol is `streamable_http`

## Testing
- `pip install -e .`
- `python -m unittest discover tests -v`


------
https://chatgpt.com/codex/tasks/task_e_6848f31c52d88333b3b854ca29175dfd